### PR TITLE
Fix typo in source

### DIFF
--- a/js/src/qtag/extract.js
+++ b/js/src/qtag/extract.js
@@ -160,7 +160,7 @@ function extractInner(d, comment, includeUnknownAttributes) {
        });
     } else if (includeUnknownAttributes) {
       tags.push({
-        "SOURCE": d.Name,
+        "SOURCE": d.name,
         "TYPE": "UNDECLARED",
         "KEY": key,
         "VALUE": comment.metadata[key]


### PR DESCRIPTION
An unknown attribute should be still given a correct soruce when using the artibrary attributes flag